### PR TITLE
Python override of dexterity schema on the fly using autoform

### DIFF
--- a/src/collective/ambidexterity/browser/editor.js
+++ b/src/collective/ambidexterity/browser/editor.js
@@ -154,6 +154,15 @@ require([
                 $('#edit_view').hide();
                 $('#remove_view').hide();
             }
+            if (inventory[content_type].has_custom_schema) {
+                $('#add_custom_schema').hide();
+                $('#edit_custom_schema').show();
+                $('#remove_custom_schema').show();
+            }else{
+                $('#add_custom_schema').show();
+                $('#edit_custom_schema').hide();
+                $('#remove_custom_schema').hide();
+            }
             $('#export_form input[name="ctype"]').val(content_type);
             if (inventory[content_type].has_view || Object.keys(inventory[content_type].fields).length > 0) {
                 $('#export_form input[type="submit"]').removeAttr('disabled');

--- a/src/collective/ambidexterity/browser/editor.pt
+++ b/src/collective/ambidexterity/browser/editor.pt
@@ -114,6 +114,12 @@ div.plone-btn-group {
           <button class="plone-btn" type="button" id="edit_view" style="display:none">Edit view</button>
           <button class="plone-btn plone-btn-danger" type="button" id="remove_view" style="display:none">Remove view</button>
         </div>
+          <div class="plone-btn-group">
+              <span class="btn-label">Schema:</span>
+              <button class="plone-btn" type="button" id="add_custom_schema" style="display:none">Add custom schema</button>
+              <button class="plone-btn" type="button" id="edit_custom_schema" style="display:none">Edit custom schema</button>
+              <button class="plone-btn plone-btn-danger" type="button" id="remove_custom_schema" style="display:none">Remove custom schema</button>
+          </div>
         <div class="plone-btn-group">
           <span class="btn-label" id="script_label">Scripts:</span>
           <button class="plone-btn" type="button" id="add_default" style="display:none">Add default</button>

--- a/src/collective/ambidexterity/browser/editor.py
+++ b/src/collective/ambidexterity/browser/editor.py
@@ -6,6 +6,7 @@ from collective.ambidexterity import models
 from collective.ambidexterity import validator_script
 from collective.ambidexterity import vocabulary_script
 from collective.ambidexterity import view as ad_view
+from collective.ambidexterity import edit as ed_view
 from collective.ambidexterity.utilities import getAmbidexterityFile
 from collective.ambidexterity.utilities import getResourcesInventory
 from plone.protect import CheckAuthenticator
@@ -127,6 +128,17 @@ class EditorAjax(BrowserView):
         elif button_id == 'remove_view':
             ad_view.rmViewTemplate(content_type)
             models.removeAmbidexterityView(content_type)
+        elif button_id == 'add_custom_schema':
+            ed_view.addCustomSchema(content_type)
+            models.setAmbidexterityEdit(content_type)
+        elif button_id == 'edit_custom_schema':
+            result = dict(
+                action='edit',
+                source=getAmbidexterityFile(content_type, None, 'schema.py'),
+            )
+        elif button_id == 'remove_custom_schema':
+            ed_view.rmCustomSchema(content_type)
+            models.removeAmbidexterityEdit(content_type)
 
         self.request.RESPONSE.setHeader(
             'Content-Type',
@@ -163,6 +175,9 @@ class EditorAjax(BrowserView):
             result = 'success'
         elif script == 'edit_view':
             ad_view.updateViewTemplate(content_type, body)
+            result = 'success'
+        elif script == 'edit_custom_schema':
+            ed_view.updateCustomSchema(content_type, body)
             result = 'success'
 
         result = dict(result=result)

--- a/src/collective/ambidexterity/configure.zcml
+++ b/src/collective/ambidexterity/configure.zcml
@@ -64,6 +64,22 @@
       layer="collective.ambidexterity.interfaces.ICollectiveAmbidexterityLayer"
       />
 
+  <browser:page
+      name="ambidexterityedit"
+      for="plone.dexterity.interfaces.IDexterityContainer"
+      class="collective.ambidexterity.edit.AmbidexterityEdit"
+      permission="cmf.ModifyPortalContent"
+      layer="collective.ambidexterity.interfaces.ICollectiveAmbidexterityLayer"
+      />
+
+  <browser:page
+      name="ambidexterityedit"
+      for="plone.dexterity.interfaces.IDexterityItem"
+      class="collective.ambidexterity.edit.AmbidexterityEdit"
+      permission="cmf.ModifyPortalContent"
+      layer="collective.ambidexterity.interfaces.ICollectiveAmbidexterityLayer"
+      />
+
   <subscriber
       for="plone.schemaeditor.interfaces.ISchemaModifiedEvent"
       handler=".subscribers.resync_if_necessary"

--- a/src/collective/ambidexterity/edit.py
+++ b/src/collective/ambidexterity/edit.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""
+    Modify a dexterity schema on the fly from a Python script executed via
+    AmbidexterityProgram.
+
+    The script is given one value (other than standard builtins):
+    "schema" -- which is the schema of the object being rendered by
+    @@ambidexterityedit
+
+    The schema should be edited using the plone.autoform setTaggedValue method.
+    See https://github.com/plone/plone.autoform/blob/master/plone/autoform/autoform.rst
+"""
+
+from AccessControl import ModuleSecurityInfo
+from AccessControl import allow_class
+
+from collective.ambidexterity.interpreter import AmbidexterityProgram
+from plone.dexterity.browser.edit import DefaultEditForm
+from plone.z3cform import layout
+from zope.interface.interface import InterfaceClass
+
+ModuleSecurityInfo('plone.autoform.interfaces').setDefaultAccess('allow')
+ModuleSecurityInfo('z3c.form.interfaces').setDefaultAccess('allow')
+allow_class(InterfaceClass)
+
+SCHEMA_SCRIPT = """# Schema Editor Script
+# You can modify the schema to be rendered using the setTaggedValue method
+# provided by plone.autoform. See
+# https://github.com/plone/plone.autoform/blob/master/plone/autoform/autoform.rst
+
+# Example code (to be used on a dexterity File object)
+from plone.autoform.interfaces import OMITTED_KEY
+from z3c.form.interfaces import IEditForm
+schema.setTaggedValue(OMITTED_KEY, ((IEditForm, 'file', True),))
+"""
+
+class AmbidexterityEditForm(DefaultEditForm):
+    """ An edit view that allows a user to modify the form before being
+        rendered.
+    """
+
+    def __init__(self, *args):
+        super(AmbidexterityEditForm, self).__init__(*args)
+
+    def updateFields(self):
+        """
+        Overrides the dexterity updateFields, creates a copy of the schema,
+        allows the schema to be updated with RestrictedPython before setting
+        the schema back to how it was after the fields are updated.
+        This allows plone.autoform functions to be called on the schema during
+        form processing.
+        :return:
+        """
+        otv = self.schema._Element__tagged_values
+        tv = getattr(self.schema, '_Element__tagged_values')
+        tv = tv and tv or {}
+        self.schema._Element__tagged_values = dict(tv)
+        cp = AmbidexterityProgram(SCHEMA_SCRIPT)
+        cp_globals = dict(schema=self.schema)
+        cp.execute(cp_globals)
+        super(AmbidexterityEditForm, self).updateFields()
+        self.schema._Element__tagged_values = otv
+
+
+AmbidexterityEdit = layout.wrap_form(AmbidexterityEditForm)
+

--- a/src/collective/ambidexterity/edit.py
+++ b/src/collective/ambidexterity/edit.py
@@ -57,8 +57,16 @@ class AmbidexterityEditForm(DefaultEditForm):
         if script is None:
             return super(AmbidexterityEditForm, self).updateFields()
 
+        # Provide the current workflow state of the context
+        state = ''
+        wft = self.context.portal_workflow
+        cur_wf = wft.getWorkflowsFor(self.context)
+        if len(cur_wf) > 0:
+            cur_wf = cur_wf[0].id
+            state = wft.getStatusOf(cur_wf, self.context)['review_state']
+
         cp = AmbidexterityProgram(script.data)
-        cp_globals = dict(schema=self.schema)
+        cp_globals = dict(schema=self.schema, context=self.context, state=state)
         try:
             cp.execute(cp_globals)
             super(AmbidexterityEditForm, self).updateFields()

--- a/src/collective/ambidexterity/models.py
+++ b/src/collective/ambidexterity/models.py
@@ -10,6 +10,7 @@ import utilities
 import re
 
 AMBIDEXTERITY_VIEW = '@@ambidexterityview'
+AMBIDEXTERITY_EDIT = '@@ambidexterityedit'
 SCHEMA_NAMESPACE = 'http://namespaces.plone.org/supermodel/schema'
 FORM_NAMESPACE = 'http://namespaces.plone.org/supermodel/form'
 
@@ -210,3 +211,17 @@ def removeAmbidexterityView(id):
     # the default_view must always be in the view methods.
     fti.manage_changeProperties(default_view=default_view)
     fti.manage_changeProperties(view_methods=tuple(view_methods))
+
+
+def setAmbidexterityEdit(id):
+    fti = getFTI(id)
+    aliases = fti.getMethodAliases()
+    aliases['edit'] = AMBIDEXTERITY_EDIT
+    fti.setMethodAliases(aliases)
+
+
+def removeAmbidexterityEdit(id):
+    fti = getFTI(id)
+    aliases = fti.getMethodAliases()
+    aliases['edit'] = '@@edit'
+    fti.setMethodAliases(aliases)

--- a/src/collective/ambidexterity/utilities.py
+++ b/src/collective/ambidexterity/utilities.py
@@ -87,6 +87,8 @@ def getResourcesInventory():
             type_folder = ambidexterity_folder.get(fid)
         if type_folder is not None and type_folder.get('view.pt') is not None:
             content_type['has_view'] = True
+        if type_folder is not None and type_folder.get('schema.py') is not None:
+            content_type['has_custom_schema'] = True
         if content_type['has_model_source']:
             for field, title, ctype in models.getFieldList(fid):
                 if type_folder is not None:


### PR DESCRIPTION
We would like to be able to modify a form at render time ttw. 

Ambidexterity provides a number of useful features for working with dexterity content ttw and we feel that this additional functionality would sit well within the ambidexterity ui/ux.

The general concept of this PR/POC is to hook into the dexterity edit form rendering and use plone.autoform directives to modify the schema.

We initially looked at using the z3c way, but that tends to require direct attribute access, which is problematic with restricted python (e.g. calling `self.widgets['somefield'].mode = HIDDEN_MODE` isn't possible in restrictedPython).

It would be good to get some feedback on this feature, whether it is useful and/or likely to be accepted? If so, I will wire up the UI elements - the current state of the PR simply executes the hardcoded script in the `SCHEMA_SCRIPT` variable.